### PR TITLE
fixed missing CURLOPT_RETURNTRANSFER in Jenkins::post()

### DIFF
--- a/src/JenkinsApi/Jenkins.php
+++ b/src/JenkinsApi/Jenkins.php
@@ -197,8 +197,9 @@ class Jenkins
 
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-        $return = curl_exec($curl);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 
+        $return = curl_exec($curl);
         return (curl_errno($curl)) ?: $return;
     }
 


### PR DESCRIPTION
This was generating strange results on our HTTP API where we are lunching a jenkins job in case something failed in jenkins